### PR TITLE
4-fix-truncation-bug

### DIFF
--- a/lib/flacinfo.rb
+++ b/lib/flacinfo.rb
@@ -691,7 +691,7 @@ class FlacInfo
       end
 
       @comment.each do |c|
-        k,v = c.split("=")
+        k,v = c.split("=", 2)
         #  Vorbis spec says we can have more than one identical comment ie:
         #  comment[0]="Artist=Charlie Parker"
         #  comment[1]="Artist=Miles Davis"


### PR DESCRIPTION
This change fixes a bug where tags containing an `=` were truncated at that character. For instance, `2 + 2 = 5` would come out as `2 + 2 =`.

I haven't included tests, but I've been using this fix in my own code for a while.